### PR TITLE
Use ExternalProject and Docker

### DIFF
--- a/test_flight_stress/client/test_do_put.py
+++ b/test_flight_stress/client/test_do_put.py
@@ -1,3 +1,86 @@
+import argparse
+import time
+from typing import List
+import pyarrow as pa
+import pyarrow.flight as flight
+import concurrent.futures
+
+PORT = 5001
+
+def get_arrow_data() -> List[pa.RecordBatch]:
+    batch1 = pa.record_batch([pa.array([1, 2, 3])], names=["x"])
+    batch2 = pa.record_batch([pa.array([4, 5, 6])], names=["x"])
+
+    return [batch1, batch2]
+
+def get_flight_client():
+    location = f"grpc+tcp://localhost:{PORT}"
+    return flight.connect(location)
+
+def do_put(n_requests: int) -> float:
+    client = get_flight_client()
+    upload_descriptor = pa.flight.FlightDescriptor.for_path("streamed.parquet")
+    data = get_arrow_data()
+    max_time = 0
+
+    for _ in range(n_requests):
+        writer, _ = client.do_put(upload_descriptor, data[0].schema)
+        start_time = time.time()
+        with writer:
+            for batch in data:
+                writer.write_batch(batch)
+        end_time = time.time()
+        max_time = max((max_time, end_time - start_time))
+
+    return max_time
 
 
+def test_do_put(method, n_workers, n_clients, n_requests):
+    # Determine method
+    if method == "process":
+        method_class = concurrent.futures.ProcessPoolExecutor
+    elif method == "thread":
+        method_class = concurrent.futures.ThreadPoolExecutor
+    else:
+        raise Exception(f"Method {method} not supported. Choose one of [process, thread]")
 
+    print(f"Running test using {method_class} with {n_workers} workers...")
+
+    with method_class(max_workers=n_workers) as executor:
+        futures = [executor.submit(do_put, n_requests) for _ in range(n_clients)]
+
+        # Collect stats
+        values = [future.result() for future in concurrent.futures.as_completed(futures)]
+        max_times = [v for v in values if v is not None]
+        errors = [v for v in values if v is None]
+        if len(max_times) == 0:
+            print(errors)
+            quit()
+        stats = {
+            "n_clients": n_clients,
+            "n_requests": n_requests,
+            "clients_in_error": len(errors),
+            "min_of_maxes": min(max_times),
+            "max_of_maxes": max(max_times)
+        }
+
+        return stats
+
+# Report status
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+                    prog = 'test_do_put.py')
+    parser.add_argument("--method", type=str, default="process")
+    parser.add_argument("--n-workers", type=int, default=10)
+    parser.add_argument("--n-clients", type=int, default=10)
+    parser.add_argument("--n-reqs", type=int, default=10)
+    args = parser.parse_args()
+
+    stats = test_do_put(
+        args.method,
+        args.n_workers,
+        args.n_clients,
+        args.n_reqs,
+    )
+    print(stats)

--- a/test_flight_stress/server/.dockerignore
+++ b/test_flight_stress/server/.dockerignore
@@ -1,0 +1,1 @@
+src/build

--- a/test_flight_stress/server/Dockerfile
+++ b/test_flight_stress/server/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+ARG build_preset=release
+
+RUN apt-get update && \
+    apt-get install -y --reinstall ca-certificates && \
+    update-ca-certificates && \
+    apt-get -y --no-install-recommends install \
+    build-essential \
+    cmake \
+    git \
+    libssl-dev
+
+ADD src src
+
+RUN cmake --preset ${build_preset} ./src && \
+    cmake --build ./src/build/${build_preset}
+
+CMD ./build/${build_preset}/server

--- a/test_flight_stress/server/Dockerfile
+++ b/test_flight_stress/server/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:22.04
 
 # Name of one of the presets in CMakePresets.json.
-ARG build_preset=release
+ARG build_type=Release
+ARG absl_version=20230125.1
+ARG protobuf_version=3.20.0
+ARG grpc_version=1.35.0
+ARG arrow_version=8.0.0
 
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
@@ -12,16 +16,77 @@ RUN --mount=type=cache,target=/var/cache/apt \
     cmake \
     ccache \
     git \
-    libssl-dev
+    libssl-dev \
+    wget
+
+# Build and install absl
+RUN git clone --branch ${absl_version} --depth 1 https://github.com/abseil/abseil-cpp && \
+    cd abseil-cpp && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=${build_type} \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DABSL_PROPAGATE_CXX_STD=ON \
+        -DCMAKE_CXX_FLAGS=-fPIC \
+        . && \
+    cmake --build . --target install --parallel 4
+ 
+# Install specific protobuf
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protobuf-cpp-${protobuf_version}.tar.gz && \
+    tar -xvf protobuf-cpp-${protobuf_version}.tar.gz && \
+    cd protobuf-${protobuf_version} && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=${build_type} \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DCMAKE_CXX_FLAGS=-fPIC \
+        cmake && \
+    cmake --build . --target install --parallel 4
+
+# Build and install grpc
+RUN git clone --branch v${grpc_version} https://github.com/grpc/grpc && \
+    cd grpc && \
+    git submodule init && \
+    git submodule update && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=${build_type} \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DABSL_PROPAGATE_CXX_STD=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_INSTALL=ON \
+        . && \
+    cmake --build . --target install --parallel 4
+
+# Build and install Arrow
+RUN git clone --branch apache-arrow-${arrow_version} --depth 1 https://github.com/apache/arrow && \
+    mkdir arrow/cpp/build && \
+    cd arrow/cpp/build && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=${build_type} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DARROW_WITH_SNAPPY=ON \
+        -DARROW_COMPUTE=ON \
+        -DARROW_PARQUET=ON \
+        -DARROW_FLIGHT=ON \
+        -DARROW_FILESYSTEM=ON \
+        -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+        -Dabsl_SOURCE=SYSTEM \
+        -DRE2_SOURCE=SYSTEM \
+        -DProtobuf_SOURCE=SYSTEM \
+        -DgRPC_SOURCE=SYSTEM \
+        .. && \
+    cmake --build . --target install --parallel 4
 
 ADD src src
 
-# TODO: cache doesn't seem to be working
-# TODO: downloading gRPC's dependencies is slow. Can we cache them?
-RUN --mount=type=cache,target=$HOME/.ccache \
-    cmake --preset ${build_preset} ./src && \
-    cmake --build ./src/build/${build_preset} --parallel 4 && \
-    mv ./src/build/${build_preset}/server ./server
+RUN mkdir build && \
+    cd build && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=${build_type} \
+        -DCMAKE_CXX_STANDARD=17 \
+        ../src && \
+    cmake --build . --parallel 4 && \
+    mv ./server ../server
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/test_flight_stress/server/Dockerfile
+++ b/test_flight_stress/server/Dockerfile
@@ -1,19 +1,30 @@
 FROM ubuntu:22.04
 
+# Name of one of the presets in CMakePresets.json.
 ARG build_preset=release
 
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
     apt-get install -y --reinstall ca-certificates && \
     update-ca-certificates && \
     apt-get -y --no-install-recommends install \
     build-essential \
     cmake \
+    ccache \
     git \
     libssl-dev
 
 ADD src src
 
-RUN cmake --preset ${build_preset} ./src && \
-    cmake --build ./src/build/${build_preset}
+# TODO: cache doesn't seem to be working
+# TODO: downloading gRPC's dependencies is slow. Can we cache them?
+RUN --mount=type=cache,target=$HOME/.ccache \
+    cmake --preset ${build_preset} ./src && \
+    cmake --build ./src/build/${build_preset} --parallel 4 && \
+    mv ./src/build/${build_preset}/server ./server
 
-CMD ./build/${build_preset}/server
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+CMD ./server 5000
+
+EXPOSE 5000/tcp

--- a/test_flight_stress/server/Dockerfile
+++ b/test_flight_stress/server/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04
 
-# Name of one of the presets in CMakePresets.json.
+# CMake build type
 ARG build_type=Release
+# Dependency versions
 ARG absl_version=20230125.1
 ARG protobuf_version=3.20.0
 ARG grpc_version=1.35.0

--- a/test_flight_stress/server/README.md
+++ b/test_flight_stress/server/README.md
@@ -1,0 +1,20 @@
+# Example server
+
+
+## Run
+
+```sh
+ARROW_VERSION=8.0.0
+GRPC_VERSION=1.35
+docker build . \
+    --tag flight-v${ARROW_VERSION}-grpc-${GRPC_VERSION} \
+    --build-arg preset=release
+```
+
+```sh
+docker run \
+    --publish 5001:5000 \
+    --env GRPC_VERBOSITY=DEBUG \
+    --env GRPC_TRACE=http,tcp,resource_quota,subchannel_pool,executor \
+    example-flight-server
+```

--- a/test_flight_stress/server/src/CMakeLists.txt
+++ b/test_flight_stress/server/src/CMakeLists.txt
@@ -3,54 +3,74 @@ project(arrow-flight-server)
 
 set(CMAKE_CXX_STANDARD 17)
 
-include(ExternalProject)
+# include(ExternalProject)
 
-ExternalProject_Add(
-  gRPC_ep
-  GIT_REPOSITORY https://github.com/grpc/grpc
-  GIT_TAG        v1.52.1
-  CMAKE_ARGS
-    -DgRPC_INSTALL=ON
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    -DCMAKE_VERBOSE_BUILD:BOOL=ON
-)
+# ExternalProject_Add(
+#   absl_ep
+#   GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+#   GIT_TAG        20230125.1
+#   CMAKE_ARGS
+#     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+#     -DCMAKE_VERBOSE_BUILD:BOOL=ON
+#     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+#     -DCMAKE_CXX_FLAGS=-fPIC
+# )
 
-ExternalProject_Add(
-  arrow_ep
-  DEPENDS gRPC_ep
-#   GIT_REPOSITORY "https://github.com/apache/arrow.git"
-#   GIT_TAG        main
-#   URL https://dlcdn.apache.org/arrow/arrow-11.0.0/apache-arrow-11.0.0.tar.gz
-#   URL_HASH SHA256=2dd8f0ea0848a58785628ee3a57675548d509e17213a2f5d72b0d900b43f5430
-#   URL https://dlcdn.apache.org/arrow/arrow-9.0.0/apache-arrow-9.0.0.tar.gz
-#   URL_HASH SHA256=a9a033f0a3490289998f458680d19579cf07911717ba65afde6cb80070f7a9b5
-  URL https://dlcdn.apache.org/arrow/arrow-8.0.0/apache-arrow-8.0.0.tar.gz
-  URL_HASH SHA256=ad9a05705117c989c116bae9ac70492fe015050e1b80fb0e38fde4b5d863aaa3
-  GIT_SHALLOW    TRUE
-  SOURCE_SUBDIR cpp
-  CMAKE_ARGS
-  -DARROW_WITH_SNAPPY=ON
-  -DARROW_COMPUTE=ON
-  -DARROW_PARQUET=ON
-  -DARROW_FLIGHT=ON
-  -DARROW_FILESYSTEM=ON
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-  -DCMAKE_VERBOSE_BUILD:BOOL=ON
-  # By default, we will use the dependencies provided by Arrow build
-  -DARROW_DEPENDENCY_SOURCE=BUNDLED
-  # But we will use gRPC and its dependencies from the gRPC external project.
-  -Dabsl_SOURCE=SYSTEM
-  -DRE2_SOURCE=SYSTEM
-  -DProtobuf_SOURCE=SYSTEM
-  -DgRPC_SOURCE=SYSTEM
-)
+# ExternalProject_Add(
+#   gRPC_ep
+#   DEPENDS absl_ep
+#   GIT_REPOSITORY https://github.com/grpc/grpc
+#   GIT_TAG        v1.35.0
+#   CMAKE_ARGS
+#     -DgRPC_INSTALL=ON
+#     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+#     -DCMAKE_VERBOSE_BUILD:BOOL=ON
+#     -DgRPC_ABSL_PROVIDER=package
+#     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+#     -DCMAKE_CXX_FLAGS=-fPIC
+# )
 
-ExternalProject_Add_StepDependencies(arrow_ep build gRPC_ep)
+# ExternalProject_Add_StepDependencies(gRPC_ep build absl_ep)
+
+# ExternalProject_Add(
+#   arrow_ep
+#   DEPENDS gRPC_ep
+# #   GIT_REPOSITORY "https://github.com/apache/arrow.git"
+# #   GIT_TAG        main
+# #   URL https://dlcdn.apache.org/arrow/arrow-11.0.0/apache-arrow-11.0.0.tar.gz
+# #   URL_HASH SHA256=2dd8f0ea0848a58785628ee3a57675548d509e17213a2f5d72b0d900b43f5430
+# #   URL https://dlcdn.apache.org/arrow/arrow-9.0.0/apache-arrow-9.0.0.tar.gz
+# #   URL_HASH SHA256=a9a033f0a3490289998f458680d19579cf07911717ba65afde6cb80070f7a9b5
+#   URL https://dlcdn.apache.org/arrow/arrow-8.0.0/apache-arrow-8.0.0.tar.gz
+#   URL_HASH SHA256=ad9a05705117c989c116bae9ac70492fe015050e1b80fb0e38fde4b5d863aaa3
+#   GIT_SHALLOW    TRUE
+#   SOURCE_SUBDIR cpp
+#   CMAKE_ARGS
+#   -DARROW_WITH_SNAPPY=ON
+#   -DARROW_COMPUTE=ON
+#   -DARROW_PARQUET=ON
+#   -DARROW_FLIGHT=ON
+#   -DARROW_FILESYSTEM=ON
+#   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+#   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+#   -DCMAKE_VERBOSE_BUILD:BOOL=ON
+#   # By default, we will use the dependencies provided by Arrow build
+#   -DARROW_DEPENDENCY_SOURCE=BUNDLED
+#   # But we will use gRPC and its dependencies from the gRPC external project.
+#   -Dabsl_SOURCE=SYSTEM
+#   -DRE2_SOURCE=SYSTEM
+#   -DProtobuf_SOURCE=SYSTEM
+#   -DgRPC_SOURCE=SYSTEM
+# )
+
+# ExternalProject_Add_StepDependencies(arrow_ep build gRPC_ep)
+
+find_package(Arrow CONFIG)
 
 add_executable(
     server
     server.cc
 )
-add_dependencies(server arrow_ep gRPC_ep)
+# add_dependencies(server arrow_ep gRPC_ep)
 
 target_link_libraries(server parquet arrow_flight arrow)

--- a/test_flight_stress/server/src/CMakeLists.txt
+++ b/test_flight_stress/server/src/CMakeLists.txt
@@ -1,26 +1,56 @@
 cmake_minimum_required(VERSION 3.19)
-project(arrow-cookbook)
+project(arrow-flight-server)
 
 set(CMAKE_CXX_STANDARD 17)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-endif()
 
-# Add Arrow and other required packages
-find_package(Arrow REQUIRED)
-if(NOT ${ARROW_VERSION} VERSION_GREATER "9.0.0")
-  get_filename_component(ARROW_CMAKE_BASE_DIR ${Arrow_CONFIG} DIRECTORY)
-  list(INSERT CMAKE_MODULE_PATH 0 ${ARROW_CMAKE_BASE_DIR})
-endif()
-find_package(ArrowFlight REQUIRED)
-find_package(Parquet REQUIRED)
-find_package(gRPC)
+include(ExternalProject)
+
+ExternalProject_Add(
+  gRPC_ep
+  GIT_REPOSITORY https://github.com/grpc/grpc
+  GIT_TAG        v1.52.1
+  CMAKE_ARGS
+    -DgRPC_INSTALL=ON
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_VERBOSE_BUILD:BOOL=ON
+)
+
+ExternalProject_Add(
+  arrow_ep
+  DEPENDS gRPC_ep
+#   GIT_REPOSITORY "https://github.com/apache/arrow.git"
+#   GIT_TAG        main
+#   URL https://dlcdn.apache.org/arrow/arrow-11.0.0/apache-arrow-11.0.0.tar.gz
+#   URL_HASH SHA256=2dd8f0ea0848a58785628ee3a57675548d509e17213a2f5d72b0d900b43f5430
+#   URL https://dlcdn.apache.org/arrow/arrow-9.0.0/apache-arrow-9.0.0.tar.gz
+#   URL_HASH SHA256=a9a033f0a3490289998f458680d19579cf07911717ba65afde6cb80070f7a9b5
+  URL https://dlcdn.apache.org/arrow/arrow-8.0.0/apache-arrow-8.0.0.tar.gz
+  URL_HASH SHA256=ad9a05705117c989c116bae9ac70492fe015050e1b80fb0e38fde4b5d863aaa3
+  GIT_SHALLOW    TRUE
+  SOURCE_SUBDIR cpp
+  CMAKE_ARGS
+  -DARROW_WITH_SNAPPY=ON
+  -DARROW_COMPUTE=ON
+  -DARROW_PARQUET=ON
+  -DARROW_FLIGHT=ON
+  -DARROW_FILESYSTEM=ON
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  -DCMAKE_VERBOSE_BUILD:BOOL=ON
+  # By default, we will use the dependencies provided by Arrow build
+  -DARROW_DEPENDENCY_SOURCE=BUNDLED
+  # But we will use gRPC and its dependencies from the gRPC external project.
+  -Dabsl_SOURCE=SYSTEM
+  -DRE2_SOURCE=SYSTEM
+  -DProtobuf_SOURCE=SYSTEM
+  -DgRPC_SOURCE=SYSTEM
+)
+
+ExternalProject_Add_StepDependencies(arrow_ep build gRPC_ep)
 
 add_executable(
     server
     server.cc
 )
+add_dependencies(server arrow_ep gRPC_ep)
 
-target_link_libraries(server parquet_shared arrow_flight_shared gRPC::grpcpp_channelz)
-target_link_libraries(parquet_shared INTERFACE arrow_shared)
-target_link_libraries(arrow_flight_shared INTERFACE arrow_shared)
+target_link_libraries(server parquet arrow_flight arrow)

--- a/test_flight_stress/server/src/CMakePresets.json
+++ b/test_flight_stress/server/src/CMakePresets.json
@@ -9,7 +9,8 @@
         {
             "name": "base",
             "hidden": true,
-            "generator": "Ninja",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {}
         },
         {

--- a/test_flight_stress/server/src/CMakePresets.json
+++ b/test_flight_stress/server/src/CMakePresets.json
@@ -11,7 +11,9 @@
             "hidden": true,
             "generator": "Unix Makefiles",
             "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {}
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+            }
         },
         {
             "name": "debug",

--- a/test_flight_stress/server/src/server.cc
+++ b/test_flight_stress/server/src/server.cc
@@ -176,14 +176,14 @@ private:
 }; // end FlightStressTestServer
 
 
-arrow::Status serve() {
+arrow::Status serve(int32_t port) {
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
   ARROW_RETURN_NOT_OK(fs->CreateDir("./flight_datasets/"));
   auto root = std::make_shared<arrow::fs::SubTreeFileSystem>("./flight_datasets/", fs);
 
   arrow::flight::Location server_location;
   ARROW_ASSIGN_OR_RAISE(server_location,
-                        arrow::flight::Location::ForGrpcTcp("0.0.0.0", 61234));
+                        arrow::flight::Location::ForGrpcTcp("0.0.0.0", port));
 
   arrow::flight::FlightServerOptions options(server_location);
   auto server = std::unique_ptr<arrow::flight::FlightServerBase>(
@@ -200,8 +200,9 @@ arrow::Status serve() {
 
 int main(int argc, char **argv)
 {
-  // TODO: accept args
-  arrow::Status st = serve();
+  int32_t port = argc > 1 ? std::atoi(argv[1]) : 5000;
+
+  arrow::Status st = serve(port);
   if (!st.ok())
   {
     return 1;

--- a/test_flight_stress/server/src/server.cc
+++ b/test_flight_stress/server/src/server.cc
@@ -12,7 +12,7 @@
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 
-#include <grpcpp/ext/channelz_service_plugin.h>
+// #include <grpcpp/ext/channelz_service_plugin.h>
 
 #include <algorithm>
 #include <memory>
@@ -190,7 +190,7 @@ arrow::Status serve() {
       new FlightStressTestServer(std::move(root)));
 
   // Must call this before server->Init();
-  grpc::channelz::experimental::InitChannelzService();
+  // grpc::channelz::experimental::InitChannelzService();
 
   ARROW_RETURN_NOT_OK(server->Init(options));
   std::cout << "Listening on port " << server->port() << std::endl;

--- a/test_flight_stress/test_log_levels.py
+++ b/test_flight_stress/test_log_levels.py
@@ -1,0 +1,81 @@
+from itertools import product
+from signal import signal, SIGINT
+import subprocess
+from time import sleep
+
+from client.test_do_put import test_do_put
+
+verbosity_levels = ["ERROR", "INFO", "DEBUG"]
+trace_options = ["tcp", "http", "flowctl", "channel", "subchannel", "api"]
+
+
+# Useless:
+# resource_quota
+# subchannel_pool
+# executor
+
+# verbosity_levels = ["DEBUG"]
+# trace_options = ["http"]
+
+class Server:
+    def __init__(self, trace_option: str, verbosity_level: str):
+        self.trace_option = trace_option
+        self.verbosity_level = verbosity_level
+        self.container_name = f"flight-trace-{trace_option}-{verbosity_level}"
+        self.docker_ps = None
+        self.log_output_file = open(f"logs/traces-{trace_option}-{verbosity_level}.log", "w")
+    
+    def __enter__(self):
+        print("starting server")
+        self.docker_ps = subprocess.Popen([
+            "docker",
+            "run",
+            "--publish",
+            "5001:5000",
+            "--env",
+            f"GRPC_VERBOSITY={self.verbosity_level}",
+            "--env",
+            f"GRPC_TRACE={self.trace_option}",
+            "--name",
+            self.container_name,
+            "example-flight-server"
+        ], stdout=self.log_output_file, stderr=self.log_output_file)
+
+        # Cleanup on interrupt
+        signal(SIGINT, lambda: self.cleanup())
+
+        return self.container_name
+
+    def cleanup(self):
+        if self.docker_ps is not None:
+            # Kill container
+            subprocess.run([
+                "docker",
+                "kill",
+                container_name
+            ])
+
+            self.docker_ps.terminate()
+
+            # delete container
+            subprocess.run([
+                "docker",
+                "rm",
+                container_name
+            ])
+        self.log_output_file.close()
+    
+    def __exit__(self, type, value, traceback):
+        self.cleanup()
+
+for verbosity_level, trace_option in product(verbosity_levels, trace_options):
+    print(f"Testing: GRPC_VERBOSITY={verbosity_level} GRPC_TRACE={trace_option}")
+
+    with Server(trace_option, verbosity_level) as container_name:
+        sleep(2) # wait for startup
+        test_do_put(
+            method="thread",
+            n_workers=2,
+            n_clients=2,
+            n_requests=2
+        )


### PR DESCRIPTION
This changes the CMakeLists.txt to use CMake's `ExternalProject` to download Arrow and gRPC. This means we now have to build Arrow, but it gives us full control over the Arrow and gRPC versions.

To make it easier to avoid conflicts with other environments, made it so we build and run the server in a Docker container.
